### PR TITLE
Fix 9 critical bugs: GPU isolation, races, deadlocks, OOM, FD leaks

### DIFF
--- a/farm.py
+++ b/farm.py
@@ -43,19 +43,20 @@ logger = logging.getLogger("orze")
 # ---------------------------------------------------------------------------
 
 def atomic_write(path: Path, content: str):
-    """Write content atomically via tmp+rename (POSIX atomic)."""
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(content)
-    tmp.rename(path)
+    """Write content atomically via tmp+replace (safe across machines)."""
+    safe_host = "".join(c if c.isalnum() else "_" for c in socket.gethostname())
+    tmp = path.with_name(f"{path.name}.{safe_host}.{os.getpid()}.tmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(path)
 
 
 def tail_file(path: Path, n_bytes: int = 4096) -> str:
     """Read last n_bytes of a file."""
     try:
         size = path.stat().st_size
-        with open(path, "r", errors="replace") as f:
+        with open(path, "rb") as f:
             f.seek(max(0, size - n_bytes))
-            return f.read()
+            return f.read().decode("utf-8", errors="replace")
     except Exception:
         return ""
 
@@ -86,13 +87,15 @@ def _fs_lock(lock_dir: Path, stale_seconds: float = 600) -> bool:
             lock_file = lock_dir / "lock.json"
             if lock_file.exists():
                 age = time.time() - lock_file.stat().st_mtime
-                if age > stale_seconds:
-                    shutil.rmtree(lock_dir)
-                    try:
-                        lock_dir.mkdir(parents=True, exist_ok=False)
-                    except FileExistsError:
-                        return False
-                else:
+            else:
+                # lock.json missing (crash between mkdir and write) — use dir mtime
+                age = time.time() - lock_dir.stat().st_mtime
+
+            if age > stale_seconds:
+                shutil.rmtree(lock_dir)
+                try:
+                    lock_dir.mkdir(parents=True, exist_ok=False)
+                except FileExistsError:
                     return False
             else:
                 return False
@@ -193,7 +196,10 @@ PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
 
 def parse_ideas(path: str) -> Dict[str, dict]:
     """Parse ideas.md into {idea_id: {title, priority, config, raw}}."""
-    text = Path(path).read_text()
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
     ideas = {}
     pattern = re.compile(r"^## (idea-\d+):\s*(.+?)$", re.MULTILINE)
     matches = list(pattern.finditer(text))
@@ -401,11 +407,15 @@ def launch(idea_id: str, gpu: int, results_dir: Path, cfg: dict) -> TrainingProc
     for k, v in cfg.get("train_extra_env", {}).items():
         env[k] = str(v)
 
-    # Keep file handle open for subprocess lifetime (fixes FD leak)
-    log_fh = open(log_path, "w")
-    proc = subprocess.Popen(
-        cmd, env=env, stdout=log_fh, stderr=subprocess.STDOUT,
-    )
+    # Keep file handle open for subprocess lifetime
+    log_fh = open(log_path, "w", encoding="utf-8")
+    try:
+        proc = subprocess.Popen(
+            cmd, env=env, stdout=log_fh, stderr=subprocess.STDOUT,
+        )
+    except Exception:
+        log_fh.close()
+        raise
 
     now = time.time()
     return TrainingProcess(
@@ -583,7 +593,8 @@ def check_active(active: Dict[int, TrainingProcess], results_dir: Path,
         else:
             reason = f"exit code {ret}"
             try:
-                lines = tp.log_path.read_text().strip().split("\n")
+                tail_str = tail_file(tp.log_path, 8192)
+                lines = tail_str.strip().split("\n")
                 tail = "\n".join(lines[-5:])
                 reason += f"\n{tail}"
             except Exception:
@@ -654,6 +665,7 @@ def run_eval(idea_id: str, gpu: int, results_dir: Path, cfg: dict):
     try:
         with open(log_path, "w") as log_fh:
             env = os.environ.copy()
+            env["CUDA_VISIBLE_DEVICES"] = str(gpu)
             for k, v in cfg.get("train_extra_env", {}).items():
                 env[k] = str(v)
             result = subprocess.run(
@@ -693,6 +705,7 @@ def run_post_scripts(idea_id: str, gpu: int, results_dir: Path, cfg: dict):
 
     python = cfg.get("python", sys.executable)
     env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(gpu)
     for k, v in cfg.get("train_extra_env", {}).items():
         env[k] = str(v)
 
@@ -1233,11 +1246,10 @@ class Orze:
 
         rules_content = rules_path.read_text()
 
-        # Substitute template vars in the rules content
-        try:
-            prompt = rules_content.format(**template_vars)
-        except KeyError:
-            prompt = rules_content
+        # Substitute template vars using explicit replace (safe with literal {})
+        prompt = rules_content
+        for k, v in template_vars.items():
+            prompt = prompt.replace(f"{{{k}}}", str(v))
 
         claude_bin = research_cfg.get("claude_bin", "claude")
         cmd = [claude_bin, "-p", prompt]

--- a/train_idea.py
+++ b/train_idea.py
@@ -135,7 +135,10 @@ def build_model(model_cfg: dict) -> nn.Module:
 
 def get_idea_config(ideas_md: str, idea_id: str) -> dict:
     """Extract a single idea's YAML config from ideas.md."""
-    text = Path(ideas_md).read_text()
+    try:
+        text = Path(ideas_md).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
     pattern = re.compile(r"^## (idea-\d+):\s*(.+?)$", re.MULTILINE)
     matches = list(pattern.finditer(text))
 
@@ -200,16 +203,42 @@ def train(args):
         transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)),
     ])
 
-    data_dir = data_cfg.get("data_dir", "./data")
+    data_dir = Path(data_cfg.get("data_dir", "./data"))
+    data_dir.mkdir(parents=True, exist_ok=True)
     num_workers = data_cfg.get("num_workers", 2)
 
+    # Cross-process lock for dataset download (prevents corruption when
+    # multiple GPUs launch simultaneously on a fresh machine)
+    lock_dir = data_dir / ".download_lock"
+    extracted_dir = data_dir / "cifar-10-batches-py"
+    needs_download = not extracted_dir.exists()
+
+    if needs_download:
+        while True:
+            try:
+                lock_dir.mkdir(exist_ok=False)
+                break
+            except FileExistsError:
+                if extracted_dir.exists():
+                    break
+                time.sleep(2)
+        try:
+            torchvision.datasets.CIFAR10(root=str(data_dir), train=True, download=True, transform=transform_train)
+            torchvision.datasets.CIFAR10(root=str(data_dir), train=False, download=True, transform=transform_test)
+        finally:
+            if lock_dir.exists():
+                try:
+                    lock_dir.rmdir()
+                except Exception:
+                    pass
+
     trainset = torchvision.datasets.CIFAR10(
-        root=data_dir, train=True, download=True, transform=transform_train)
+        root=str(data_dir), train=True, download=False, transform=transform_train)
     trainloader = torch.utils.data.DataLoader(
         trainset, batch_size=batch_size, shuffle=True, num_workers=num_workers)
 
     testset = torchvision.datasets.CIFAR10(
-        root=data_dir, train=False, download=True, transform=transform_test)
+        root=str(data_dir), train=False, download=False, transform=transform_test)
     testloader = torch.utils.data.DataLoader(
         testset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
 


### PR DESCRIPTION
## Summary
- **GPU isolation breach** — `run_eval()` and `run_post_scripts()` now set `CUDA_VISIBLE_DEVICES`, preventing OOM crashes on concurrent jobs
- **`atomic_write` race** — tmp files qualified with hostname+PID, uses `.replace()` instead of `.rename()`
- **`_fs_lock` deadlock** — falls back to directory mtime when `lock.json` is missing (crash between mkdir and write)
- **Memory exhaustion** — `check_active()` uses `tail_file()` instead of `read_text()` on potentially huge logs
- **`tail_file` OSError** — opens in binary mode for safe arbitrary-offset seek
- **Claude prompt crash** — uses `str.replace()` instead of `.format()` to handle literal `{}` in rules files
- **Dataset download corruption** — `train_idea.py` uses mkdir spin-lock so parallel workers don't corrupt CIFAR10
- **FD leak on launch failure** — closes log file handle if `Popen` raises
- **Missing `ideas.md` crash** — `parse_ideas()` and `get_idea_config()` return empty dict on `FileNotFoundError`

## Test plan
- [ ] Launch 8 parallel workers on fresh machine — verify no CIFAR10 download corruption
- [ ] Kill orchestrator mid-lock — verify it recovers on restart (no permanent deadlock)
- [ ] Run eval while other GPUs train — verify no OOM from GPU isolation breach
- [ ] Start with no `ideas.md` — verify orchestrator waits for research agent instead of crashing
- [ ] Generate 10GB+ log file — verify orchestrator doesn't OOM reading it

🤖 Generated with [Claude Code](https://claude.com/claude-code)