### PR TITLE
Add multi-role agent system

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -99,12 +99,13 @@ stall_minutes: 30
 max_idea_failures: 3
 min_disk_gb: 20
 
-research:
-  mode: claude
-  rules_file: RESEARCH_RULES.md
-  model: sonnet
-  cooldown: 300
-  timeout: 600
+roles:
+  research:
+    mode: claude
+    rules_file: RESEARCH_RULES.md
+    model: sonnet
+    cooldown: 300
+    timeout: 600
 
 report:
   title: "Research Report"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ python orze/farm.py -c orze.yaml
 
 ## Key Features
 
+- **Agent roles** — multiple agents (research, documenter, analyzer, etc.) run alongside training
 - **Research agent** — Claude CLI or any script generates ideas automatically
 - **Multi-GPU** — claims and trains across all GPUs in parallel
 - **Health monitoring** — stall detection, OOM detection, disk space checks
@@ -108,7 +109,8 @@ python orze/farm.py [OPTIONS]
   --gpus GPU_IDS           Comma-separated GPU IDs (default: all)
   --once                   Run one cycle and exit
   --report-only            Only regenerate report.md
-  --research-only          Only run research agent once
+  --role-only NAME         Run a single agent role once and exit
+  --research-only          Alias for --role-only research
   -v, --verbose            Debug logging
 ```
 

--- a/RULES.md
+++ b/RULES.md
@@ -203,9 +203,41 @@ Set `min_disk_gb` to pause new launches when disk space is low:
 min_disk_gb: 50   # pause if < 50GB free
 ```
 
-## Orze as Research Commander
+## Agent Roles
 
-Orze is the **single entry point** for the entire auto-research loop. It manages everything: spawning the research agent, training ideas, evaluating results, and feeding results back to the research agent. One process, one command.
+Orze supports multiple **agent roles** that run alongside training. Each role is an independently scheduled subprocess with its own cooldown, timeout, lock, state, and log directory.
+
+The most common role is `research` (generates new experiment ideas), but you can add any role: `documenter`, `analyzer`, `pruner`, etc.
+
+### Configuration
+
+Roles are defined under the `roles:` key in `orze.yaml`:
+
+```yaml
+roles:
+  research:
+    mode: claude
+    rules_file: RESEARCH_RULES.md
+    cooldown: 300
+    timeout: 600
+    model: sonnet
+    allowed_tools: "Read,Write,Edit,Glob,Grep,Bash"
+    log_dir: _research_logs
+
+  documenter:
+    mode: claude
+    rules_file: DOCUMENTER_RULES.md
+    cooldown: 600
+    timeout: 300
+    model: haiku
+    log_dir: _documenter_logs
+```
+
+**Legacy support**: A top-level `research:` key (without `roles:`) is auto-migrated to `roles: {research: ...}`.
+
+### Role Modes
+
+Each role supports two modes: **script** or **claude**.
 
 ### The Full Loop
 
@@ -225,62 +257,54 @@ Orze is the **single entry point** for the entire auto-research loop. It manages
 ```
 
 Each iteration:
-1. Orze spawns the **research agent** (subprocess, rate-limited by cooldown timer)
-2. Research agent reads `results/report.md` and `results/status.json`, appends new ideas to `ideas.md`
+1. Orze runs all configured **agent roles** (each independently rate-limited)
+2. Research role reads `results/report.md` and `results/status.json`, appends new ideas to `ideas.md`
 3. Orze parses `ideas.md`, claims unclaimed ideas, launches **training** on free GPUs
 4. Training completes → orze runs **evaluation** and **post-scripts**
 5. Orze updates `report.md` and `status.json`
 6. Loop repeats
 
-### Research Configuration
-
-Two modes: **script** (call any Python script) or **claude** (use Claude CLI directly).
-
-#### Mode: script (for custom research scripts)
+#### Mode: script (run any Python script)
 
 ```yaml
-research:
-  mode: script                     # default
-  script: research_agent.py        # your research script
-  args: ["--ideas-md", "{ideas_file}", "--results-dir", "{results_dir}"]
-  timeout: 600                     # max time per cycle (seconds)
-  cooldown: 300                    # min seconds between cycles
-  log_dir: _research_logs          # relative to results_dir
-  env:                             # extra env vars (API keys, etc.)
-    ANTHROPIC_API_KEY: sk-...
+roles:
+  my_role:
+    mode: script
+    script: my_agent.py
+    args: ["--ideas-md", "{ideas_file}", "--results-dir", "{results_dir}"]
+    timeout: 600
+    cooldown: 300
+    log_dir: _my_role_logs
+    env:
+      ANTHROPIC_API_KEY: sk-...
 ```
 
-Template variables for `args`: `{ideas_file}`, `{results_dir}`, `{cycle}`, `{gpu_count}`, `{completed}`, `{queued}`.
+Template variables for `args`: `{ideas_file}`, `{results_dir}`, `{cycle}`, `{gpu_count}`, `{completed}`, `{queued}`, `{role_name}`.
 
 #### Mode: claude (use Claude CLI — no API keys needed)
 
 ```yaml
-research:
-  mode: claude
-  rules_file: RESEARCH_RULES.md    # prompt/instructions file for Claude
-  cooldown: 300
-  timeout: 600
-  model: sonnet                    # optional: sonnet, opus, haiku
-  allowed_tools: "Read,Write,Edit,Glob,Grep,Bash"  # tools Claude can use
-  claude_bin: claude               # path to Claude CLI binary
-  claude_args: []                  # extra CLI flags
+roles:
+  my_role:
+    mode: claude
+    rules_file: MY_ROLE_RULES.md
+    cooldown: 300
+    timeout: 600
+    model: sonnet
+    allowed_tools: "Read,Write,Edit,Glob,Grep,Bash"
+    claude_bin: claude
+    claude_args: []
 ```
 
-In this mode, orze spawns `claude -p "<rules_file content>" --allowedTools ... --model ...` as a subprocess. Claude reads results, generates ideas, and appends them to `ideas.md` — all via its native file tools. No API keys needed since Claude CLI handles its own auth.
+In this mode, orze spawns `claude -p "<rules_file content>" --allowedTools ... --model ...` as a subprocess. The `rules_file` supports the same template variables.
 
-The `rules_file` supports the same template variables: `{ideas_file}`, `{results_dir}`, `{cycle}`, `{completed}`, `{queued}`, `{gpu_count}`.
+### Role Behavior
 
-### Research Script Contract (mode: script)
-
-**Input**: The command from `research.args` with template variables substituted.
-
-**Expected behavior**:
-1. Read `results/report.md` and/or `results/status.json` to understand current state
-2. Analyze what's working (top results) and what's failing
-3. Generate new experiment ideas
-4. Append them to `ideas.md` (following the Ideas Format above)
-
-**Output**: Append new ideas to `ideas.md`. Print "N new ideas" to stdout for logging.
+- **Independent**: Each role has its own cooldown timer, cycle counter, and filesystem lock
+- **Non-fatal**: If any role crashes or times out, orze logs a warning and continues. Roles never block training
+- **Rate-limited**: Each role's `cooldown` timer prevents excessive runs
+- **Logged**: Cycles go to `results/{log_dir}/cycle_NNN.log`
+- **Cross-machine safe**: Each role uses its own `_{role_name}_lock` directory for coordination
 
 ### Research Rules Contract (mode: claude)
 
@@ -313,33 +337,33 @@ model:
 \```
 ```
 
-### Research Behavior (both modes)
-
-- **Non-fatal**: If the research agent crashes or times out, orze logs a warning and continues training. Research never blocks execution.
-- **Rate-limited**: The `cooldown` timer prevents excessive API/LLM calls.
-- **Logged**: All cycles go to `results/_research_logs/cycle_NNN.log`.
-
-### Running Research Manually
+### Running Roles Manually
 
 ```bash
 # Run one research cycle and exit
+python farm.py -c orze.yaml --role-only research
+
+# Legacy alias for the above
 python farm.py -c orze.yaml --research-only
 
-# The full loop (research + train + eval, continuous)
+# Run only the documenter role once
+python farm.py -c orze.yaml --role-only documenter
+
+# The full loop (all roles + train + eval, continuous)
 python farm.py -c orze.yaml
 ```
 
 ### Multi-Machine Setup
 On machines sharing a filesystem:
 ```bash
-# Machine 1 (commander — runs research + training)
+# Machine 1 (commander — runs roles + training)
 python farm.py -c orze.yaml --gpus 0,1,2,3
 
-# Machine 2 (worker — just runs training, no research config)
+# Machine 2 (worker — just runs training, no roles configured)
 python farm.py -c orze.yaml --gpus 0,1,2,3
 ```
 
-Only one machine should have `research:` configured (the commander). Workers just train whatever ideas are in the queue. The atomic mkdir prevents duplicate claims.
+Only one machine should have roles configured (the commander). Workers just train whatever ideas are in the queue. The atomic mkdir prevents duplicate claims.
 
 ## Phase Transitions
 
@@ -502,6 +526,8 @@ Options:
   --poll SECONDS           Loop sleep interval (default: 30)
   --once                   Run one cycle and exit
   --report-only            Only regenerate report.md
+  --role-only NAME         Run a single agent role once and exit
+  --research-only          Alias for --role-only research
   --ideas-md PATH          Ideas file path
   --base-config PATH       Base config YAML path
   --results-dir PATH       Results directory

--- a/farm.py
+++ b/farm.py
@@ -13,6 +13,7 @@ Usage:
     python farm.py -c orze.yaml --gpus 0,1      # with project config
     python farm.py --once                       # one cycle then exit
     python farm.py --report-only                # just regenerate report
+    python farm.py --role-only research         # run one role once
 """
 
 import argparse
@@ -165,6 +166,7 @@ DEFAULT_CONFIG = {
     "max_idea_failures": 0,     # 0 = disabled (never skip)
     "min_disk_gb": 0,           # 0 = disabled
     "orphan_timeout_hours": 0,  # 0 = disabled
+    "roles": {},
 }
 
 
@@ -183,6 +185,13 @@ def load_project_config(path: Optional[str]) -> dict:
         logger.info("Loaded config from %s", path)
     elif path:
         logger.warning("Config file %s not found, using defaults", path)
+
+    # Migrate legacy research: into roles: dict
+    if "research" in cfg and isinstance(cfg["research"], dict):
+        if not cfg.get("roles"):
+            cfg["roles"] = {"research": cfg["research"]}
+        elif "research" not in cfg["roles"]:
+            cfg["roles"]["research"] = cfg["research"]
 
     return cfg
 
@@ -1008,8 +1017,7 @@ def write_status_json(results_dir: Path, iteration: int,
                       completed_count: int, failed_count: int,
                       skipped_count: int, top_results: list,
                       cfg: dict,
-                      research_cycles: int = 0,
-                      last_research_time: float = 0.0):
+                      role_states: Optional[dict] = None):
     """Write machine-readable status.json for LLM agents.
     Merges heartbeats from all hosts for a combined multi-machine view."""
     disk_free_gb = 0.0
@@ -1020,10 +1028,6 @@ def write_status_json(results_dir: Path, iteration: int,
         pass
 
     now = time.time()
-    last_research_min_ago = (
-        round((now - last_research_time) / 60, 1)
-        if last_research_time > 0 else None
-    )
 
     # Merge active processes from all hosts
     heartbeats = _read_all_heartbeats(results_dir)
@@ -1035,6 +1039,25 @@ def write_status_json(results_dir: Path, iteration: int,
             a["host"] = host
             all_active.append(a)
         free_gpus_by_host[host] = hb.get("free_gpus", [])
+
+    # Build per-role status
+    role_states = role_states or {}
+    roles_cfg = cfg.get("roles", {})
+    roles_status = {}
+    for rname in roles_cfg:
+        rs = role_states.get(rname, {})
+        last_run = rs.get("last_run_time", 0.0)
+        roles_status[rname] = {
+            "enabled": True,
+            "cycles": rs.get("cycles", 0),
+            "last_run_min_ago": (
+                round((now - last_run) / 60, 1) if last_run > 0 else None
+            ),
+        }
+
+    # Backward compat: flat research_* keys
+    research_rs = role_states.get("research", {})
+    research_last = research_rs.get("last_run_time", 0.0)
 
     hostname = socket.gethostname()
     status = {
@@ -1050,9 +1073,13 @@ def write_status_json(results_dir: Path, iteration: int,
         "skipped": skipped_count,
         "disk_free_gb": round(disk_free_gb, 1),
         "top_results": top_results[:10],
-        "research_enabled": bool(cfg.get("research", {}).get("script")),
-        "research_cycles": research_cycles,
-        "last_research_min_ago": last_research_min_ago,
+        "roles": roles_status,
+        "research_enabled": "research" in roles_cfg,
+        "research_cycles": research_rs.get("cycles", 0),
+        "last_research_min_ago": (
+            round((now - research_last) / 60, 1) if research_last > 0
+            else None
+        ),
     }
 
     atomic_write(results_dir / "status.json", json.dumps(status, indent=2))
@@ -1071,7 +1098,8 @@ def save_state(results_dir: Path, state: dict):
 
 def load_state(results_dir: Path) -> dict:
     """Load orchestrator state from checkpoint (per-host).
-    Falls back to legacy .orze_state.json for backward compat."""
+    Falls back to legacy .orze_state.json for backward compat.
+    Migrates legacy flat research_* keys into roles dict."""
     hostname = socket.gethostname()
     path = results_dir / f".orze_state_{hostname}.json"
 
@@ -1082,10 +1110,22 @@ def load_state(results_dir: Path) -> dict:
 
     if path.exists():
         try:
-            return json.loads(path.read_text())
+            state = json.loads(path.read_text())
         except json.JSONDecodeError:
             logger.warning("Corrupt state file, starting fresh")
-    return {"iteration": 0, "failure_counts": {}}
+            return {"iteration": 0, "failure_counts": {}, "roles": {}}
+
+        # Migrate legacy flat research state into roles dict
+        if "roles" not in state and "research_cycles" in state:
+            state["roles"] = {
+                "research": {
+                    "cycles": state.pop("research_cycles", 0),
+                    "last_run_time": state.pop("last_research_time", 0.0),
+                }
+            }
+        state.setdefault("roles", {})
+        return state
+    return {"iteration": 0, "failure_counts": {}, "roles": {}}
 
 
 # ---------------------------------------------------------------------------
@@ -1105,9 +1145,8 @@ class Orze:
         self.iteration = state.get("iteration", 0)
         self.failure_counts = state.get("failure_counts", {})
 
-        # Research agent state
-        self.research_cycles = state.get("research_cycles", 0)
-        self.last_research_time = state.get("last_research_time", 0.0)
+        # Per-role agent state: {role_name: {"cycles": int, "last_run_time": float}}
+        self.role_states: Dict[str, dict] = state.get("roles", {})
 
         self.results_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1130,81 +1169,81 @@ class Orze:
         save_state(self.results_dir, {
             "iteration": self.iteration,
             "failure_counts": self.failure_counts,
-            "research_cycles": self.research_cycles,
-            "last_research_time": self.last_research_time,
+            "roles": self.role_states,
         })
         logger.info("Shutdown complete.")
         sys.exit(0)
 
-    def _run_research_step(self):
-        """Run the research agent to generate new ideas (rate-limited).
+    def _run_role_step(self, role_name: str, role_cfg: dict):
+        """Run an agent role (rate-limited, locked, logged).
 
         Supports two modes:
-          - mode: script  — run a Python script (default)
+          - mode: script  — run a Python script
           - mode: claude  — run Claude CLI with a rules/prompt file
         """
-        research_cfg = self.cfg.get("research")
-        if not research_cfg:
+        mode = role_cfg.get("mode", "script")
+        if mode == "script" and not role_cfg.get("script"):
+            return
+        if mode == "claude" and not role_cfg.get("rules_file"):
             return
 
-        mode = research_cfg.get("mode", "script")
-        if mode == "script" and not research_cfg.get("script"):
-            return
-        if mode == "claude" and not research_cfg.get("rules_file"):
-            return
-
-        cooldown = research_cfg.get("cooldown", 300)
-        elapsed = time.time() - self.last_research_time
+        # Per-role cooldown
+        role_state = self.role_states.setdefault(
+            role_name, {"cycles": 0, "last_run_time": 0.0})
+        cooldown = role_cfg.get("cooldown", 300)
+        elapsed = time.time() - role_state["last_run_time"]
         if elapsed < cooldown:
             return
 
-        timeout = research_cfg.get("timeout", 600)
+        timeout = role_cfg.get("timeout", 600)
 
-        # Acquire cross-machine lock (only one host runs research at a time)
-        lock_dir = self.results_dir / "_research_lock"
+        # Per-role cross-machine lock
+        lock_dir = self.results_dir / f"_{role_name}_lock"
         if not _fs_lock(lock_dir, stale_seconds=timeout + 60):
-            logger.debug("Research lock held by another host, skipping")
+            logger.debug("%s lock held by another host, skipping", role_name)
             return
 
-        # Count current status for template vars
+        # Template variables (shared across all roles)
         ideas = parse_ideas(self.cfg["ideas_file"])
         counts = _count_statuses(ideas, self.results_dir)
         template_vars = {
             "ideas_file": self.cfg["ideas_file"],
             "results_dir": str(self.results_dir),
-            "cycle": self.research_cycles + 1,
+            "cycle": role_state["cycles"] + 1,
             "gpu_count": len(self.gpu_ids),
             "completed": counts.get("COMPLETED", 0),
             "queued": counts.get("QUEUED", 0),
+            "role_name": role_name,
         }
 
         # Build command based on mode
         if mode == "claude":
-            cmd = self._build_claude_cmd(research_cfg, template_vars)
+            cmd = self._build_claude_cmd(role_cfg, template_vars)
             if not cmd:
+                _fs_unlock(lock_dir)
                 return
         else:
             python = self.cfg.get("python", sys.executable)
-            cmd = [python, research_cfg["script"]]
-            for arg in research_cfg.get("args", []):
+            cmd = [python, role_cfg["script"]]
+            for arg in role_cfg.get("args", []):
                 cmd.append(str(arg).format(**template_vars))
 
         # Environment
         env = os.environ.copy()
         for k, v in self.cfg.get("train_extra_env", {}).items():
             env[k] = str(v)
-        for k, v in research_cfg.get("env", {}).items():
+        for k, v in role_cfg.get("env", {}).items():
             env[k] = str(v)
 
-        # Log directory
-        log_dir_name = research_cfg.get("log_dir", "_research_logs")
+        # Per-role log directory
+        log_dir_name = role_cfg.get("log_dir", f"_{role_name}_logs")
         log_dir = self.results_dir / log_dir_name
         log_dir.mkdir(parents=True, exist_ok=True)
-        cycle_num = self.research_cycles + 1
+        cycle_num = role_state["cycles"] + 1
         log_path = log_dir / f"cycle_{cycle_num:03d}.log"
 
-        logger.info("Running research agent [%s] (cycle %d)...",
-                     mode, cycle_num)
+        logger.info("Running %s [%s] (cycle %d)...",
+                     role_name, mode, cycle_num)
 
         try:
             with open(log_path, "w") as log_fh:
@@ -1213,27 +1252,31 @@ class Orze:
                     timeout=timeout,
                 )
 
-            self.last_research_time = time.time()
-            self.research_cycles += 1
+            role_state["last_run_time"] = time.time()
+            role_state["cycles"] += 1
 
             if result.returncode == 0:
-                n_new = self._count_new_ideas(log_path)
-                logger.info("Research cycle %d completed (%d new ideas)",
-                            cycle_num, n_new)
+                logger.info("%s cycle %d completed", role_name, cycle_num)
             else:
                 logger.warning(
-                    "Research agent failed (exit %d), see %s",
-                    result.returncode, log_path)
+                    "%s failed (exit %d), see %s",
+                    role_name, result.returncode, log_path)
 
         except subprocess.TimeoutExpired:
-            self.last_research_time = time.time()
-            self.research_cycles += 1
-            logger.warning("Research agent timed out after %ds", timeout)
+            role_state["last_run_time"] = time.time()
+            role_state["cycles"] += 1
+            logger.warning("%s timed out after %ds", role_name, timeout)
         except Exception as e:
-            self.last_research_time = time.time()
-            logger.warning("Research agent error: %s", e)
+            role_state["last_run_time"] = time.time()
+            logger.warning("%s error: %s", role_name, e)
         finally:
             _fs_unlock(lock_dir)
+
+    def _run_all_roles(self):
+        """Run all configured agent roles (each independently rate-limited)."""
+        for role_name, role_cfg in self.cfg.get("roles", {}).items():
+            if isinstance(role_cfg, dict):
+                self._run_role_step(role_name, role_cfg)
 
     def _build_claude_cmd(self, research_cfg: dict,
                           template_vars: dict) -> Optional[List[str]]:
@@ -1295,16 +1338,17 @@ class Orze:
         logger.info("Ideas: %s | Results: %s | Timeout: %ds | Poll: %ds",
                      cfg["ideas_file"], cfg["results_dir"],
                      cfg["timeout"], cfg["poll"])
-        research_cfg = cfg.get("research", {})
-        research_mode = research_cfg.get("mode", "script")
-        research_target = (research_cfg.get("rules_file")
-                           if research_mode == "claude"
-                           else research_cfg.get("script"))
-        if research_target:
-            logger.info("Research [%s]: %s (cooldown: %ds, timeout: %ds)",
-                        research_mode, research_target,
-                        research_cfg.get("cooldown", 300),
-                        research_cfg.get("timeout", 600))
+        for rname, rcfg in cfg.get("roles", {}).items():
+            if not isinstance(rcfg, dict):
+                continue
+            rmode = rcfg.get("mode", "script")
+            rtarget = (rcfg.get("rules_file") if rmode == "claude"
+                       else rcfg.get("script"))
+            if rtarget:
+                logger.info("Role '%s' [%s]: %s (cooldown: %ds, timeout: %ds)",
+                            rname, rmode, rtarget,
+                            rcfg.get("cooldown", 300),
+                            rcfg.get("timeout", 600))
 
         while self.running:
             self.iteration += 1
@@ -1359,8 +1403,8 @@ class Orze:
                     except json.JSONDecodeError:
                         pass
 
-            # 5. Run research agent to generate new ideas
-            self._run_research_step()
+            # 5. Run agent roles (research, documenter, etc.)
+            self._run_all_roles()
 
             # 6. Parse ideas and find unclaimed
             ideas = parse_ideas(cfg["ideas_file"])
@@ -1433,16 +1477,14 @@ class Orze:
                 self.results_dir, self.iteration, self.active, free,
                 len(unclaimed), counts.get("COMPLETED", 0),
                 counts.get("FAILED", 0), len(skipped), top_results, cfg,
-                research_cycles=self.research_cycles,
-                last_research_time=self.last_research_time,
+                role_states=self.role_states,
             )
 
             # 10. Save state
             save_state(self.results_dir, {
                 "iteration": self.iteration,
                 "failure_counts": self.failure_counts,
-                "research_cycles": self.research_cycles,
-                "last_research_time": self.last_research_time,
+                "roles": self.role_states,
             })
 
             if self.once:
@@ -1517,8 +1559,10 @@ Examples:
                         help="Run one cycle and exit")
     parser.add_argument("--report-only", action="store_true",
                         help="Only regenerate report")
+    parser.add_argument("--role-only", type=str, default=None, metavar="NAME",
+                        help="Run a single agent role once and exit")
     parser.add_argument("--research-only", action="store_true",
-                        help="Only run research agent once and exit")
+                        help="Alias for --role-only research")
     parser.add_argument("--ideas-md", type=str, default=None,
                         help="Path to ideas markdown file")
     parser.add_argument("--base-config", type=str, default=None,
@@ -1565,22 +1609,30 @@ Examples:
         update_report(Path(cfg["results_dir"]), ideas, cfg)
         return
 
-    # Research-only mode
+    # Role-only mode (--role-only NAME or --research-only)
+    role_only = args.role_only
     if args.research_only:
-        research_cfg = cfg.get("research")
-        if not research_cfg:
-            logger.error("No research section configured in orze.yaml")
+        role_only = "research"
+    if role_only:
+        roles_cfg = cfg.get("roles", {})
+        role_cfg = roles_cfg.get(role_only)
+        if not role_cfg or not isinstance(role_cfg, dict):
+            logger.error("No role '%s' configured in orze.yaml", role_only)
             sys.exit(1)
-        mode = research_cfg.get("mode", "script")
-        has_target = (research_cfg.get("rules_file") if mode == "claude"
-                      else research_cfg.get("script"))
+        mode = role_cfg.get("mode", "script")
+        has_target = (role_cfg.get("rules_file") if mode == "claude"
+                      else role_cfg.get("script"))
         if not has_target:
-            logger.error("No research.%s configured in orze.yaml",
+            logger.error("No %s.%s configured in orze.yaml",
+                         role_only,
                          "rules_file" if mode == "claude" else "script")
             sys.exit(1)
         orze = Orze(gpu_ids, cfg, once=True)
-        orze.last_research_time = 0.0  # Force immediate run
-        orze._run_research_step()
+        # Force immediate run by zeroing cooldown
+        rs = orze.role_states.setdefault(
+            role_only, {"cycles": 0, "last_run_time": 0.0})
+        rs["last_run_time"] = 0.0
+        orze._run_role_step(role_only, role_cfg)
         return
 
     orze = Orze(gpu_ids, cfg, once=args.once)

--- a/orze.yaml.example
+++ b/orze.yaml.example
@@ -56,31 +56,45 @@ orphan_timeout_hours: 0              # reclaim orphaned claims after N hours
 #     args: ["--idea-id", "{idea_id}"]
 #     timeout: 600
 
-# --- Research agent (optional) ---
-# Spawns an LLM to generate new ideas based on results.
-# Two modes: "script" (Python script) or "claude" (Claude CLI).
+# --- Agent roles (optional) ---
+# Each role is an independently scheduled agent that runs alongside training.
+# Each gets its own cooldown, timeout, lock, state, and log directory.
+# Two modes per role: "script" (Python script) or "claude" (Claude CLI).
 #
-# Mode: script (default) — run any Python script
-# research:
-#   mode: script
-#   script: research_agent.py
-#   args: ["--ideas-md", "{ideas_file}", "--results-dir", "{results_dir}", "--cycle", "{cycle}"]
-#   timeout: 600                       # max time per research cycle (seconds)
-#   cooldown: 300                      # min seconds between research cycles
-#   log_dir: _research_logs            # relative to results_dir
-#   env:                               # extra env vars (e.g., API keys)
-#     ANTHROPIC_API_KEY: sk-...
+# roles:
+#   research:
+#     mode: claude
+#     rules_file: RESEARCH_RULES.md
+#     cooldown: 300
+#     timeout: 600
+#     model: sonnet
+#     allowed_tools: "Read,Write,Edit,Glob,Grep,Bash"
+#     log_dir: _research_logs          # relative to results_dir
 #
-# Mode: claude — use Claude CLI directly (no API keys needed)
+#   documenter:
+#     mode: claude
+#     rules_file: DOCUMENTER_RULES.md
+#     cooldown: 600
+#     timeout: 300
+#     model: haiku
+#     log_dir: _documenter_logs
+#
+#   analyzer:
+#     mode: script
+#     script: analysis_agent.py
+#     args: ["--results-dir", "{results_dir}", "--cycle", "{cycle}"]
+#     timeout: 600
+#     cooldown: 300
+#     log_dir: _analyzer_logs
+#     env:
+#       ANTHROPIC_API_KEY: sk-...
+#
+# Legacy: top-level "research:" still works (auto-migrated to roles.research)
 # research:
 #   mode: claude
-#   rules_file: RESEARCH_RULES.md      # prompt/instructions for Claude
+#   rules_file: RESEARCH_RULES.md
 #   cooldown: 300
 #   timeout: 600
-#   model: sonnet                      # optional: sonnet, opus, haiku
-#   allowed_tools: "Read,Write,Edit,Glob,Grep,Bash"
-#   claude_bin: claude                 # path to claude CLI
-#   claude_args: []                    # extra CLI flags
 
 # --- Garbage collection (optional) ---
 # cleanup:


### PR DESCRIPTION
## Summary
- Generalizes the single `research:` agent into a `roles:` dict supporting multiple independent agents (research, documenter, analyzer, etc.)
- Each role gets its own cooldown, timeout, filesystem lock, cycle state, and log directory
- Legacy `research:` config auto-migrates to `roles: {research: ...}` for backward compatibility
- Adds `--role-only NAME` CLI flag; `--research-only` kept as alias

## Test plan
- [ ] Verify existing `research:` config still works (backward compat)
- [ ] Verify `--research-only` still works
- [ ] Verify `--role-only research` runs just the research role
- [ ] Verify state file migrates legacy flat keys to `roles` dict
- [ ] Verify each role gets independent lock dir and log dir
- [ ] Syntax check: `python3 -c "import ast; ast.parse(open('farm.py').read())"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)