### PR TITLE
feat: v1.10.0 — admin panel performance + generic cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ nohup python orze/bug_fixer.py -c orze.yaml >> results/bug_fixer.log 2>&1 &
 - **Multi-machine** — works across machines on shared filesystems (NFS/EFS/FSx)
 - **Failure handling** — auto-skip after N failures, orphan cleanup
 - **Self-healing** — companion `bug_fixer.py` watchdog runs alongside farm.py, auto-restarts crashed processes, kills stuck jobs, and delegates all error diagnosis to an LLM agent (no hardcoded error patterns)
-- **Admin panel** — web dashboard at `:8787` with real-time overview, fleet status, run management, paginated queue browser with HuggingFace model info, leaderboard, and alerts. Kill runs or stop all from the UI
+- **Admin panel** — web dashboard at `:8787` with real-time overview, node status, run management, paginated queue browser with HuggingFace model info, leaderboard, and alerts. Kill runs or stop all from the UI. Primary node pre-aggregates all data for instant (<5ms) API responses
 - **Model discovery** — `hf_discover.py` queries HuggingFace for trending models by task/tag. Use it in a `mode: script` role to auto-discover new SOTA backbones without manual work
 - **Idea Lake** — SQLite-backed archive for completed/failed experiments. Metrics stored as generic JSON blobs (no project-specific schema). Training and eval scripts check the lake when an idea isn't in ideas.md
 - **Corruption guard** — detects if a research agent truncates ideas.md and auto-restores from rotating `.safe` backups
@@ -283,14 +283,16 @@ nohup python -m orze.admin.server -c orze.yaml &
 
 Tabs:
 - **Overview** — GPU utilization, VRAM, queue depth, active runs, top results
-- **Fleet** — per-host heartbeat status, GPU cards with temp/util/VRAM bars
+- **Nodes** — per-host heartbeat status, GPU cards with temp/util/VRAM bars
 - **Runs** — active + recent runs with log viewer, kill individual runs
 - **Queue** — paginated browser (50/page) with status/text filters, priority badges, sweep grouping, expandable config + hypothesis, HuggingFace model links
-- **Leaderboard** — top models ranked by primary metric
+- **Leaderboard** — top models ranked by primary metric (unified with Telegram bot)
 - **Alerts** — recent failures, stale hosts, low disk warnings
 - **Settings** — live view of orze.yaml (secrets masked)
 
 Actions: **Stop All** (writes stop sentinel) and **Kill Run** (per-idea `.kill` file) directly from the UI.
+
+**Performance:** The primary farm.py node pre-aggregates all admin data (`_admin_cache.json`, `_leaderboard.json`) each loop iteration. The admin server reads these cached files — all endpoints respond in <5ms. Loading spinners and module-level response caching give instant tab switching in the UI.
 
 ## CLI Reference
 

--- a/admin/server.py
+++ b/admin/server.py
@@ -47,7 +47,7 @@ _SENSITIVE_KEYS = {
     "ANTHROPIC_API_KEY", "LLM_API_KEY",
 }
 
-app = FastAPI(title="Orze Admin Panel", version="0.1.0")
+app = FastAPI(title="Orze Admin Panel", version="1.10.0")
 
 from starlette.middleware.gzip import GZipMiddleware
 app.add_middleware(GZipMiddleware, minimum_size=500)

--- a/bot.py
+++ b/bot.py
@@ -27,7 +27,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
-__version__ = "1.8.0"
+__version__ = "1.10.0"
 
 logging.basicConfig(
     level=logging.INFO,

--- a/farm.py
+++ b/farm.py
@@ -42,7 +42,7 @@ import atexit
 
 import yaml
 
-__version__ = "1.8.1"
+__version__ = "1.10.0"
 
 logger = logging.getLogger("orze")
 


### PR DESCRIPTION
## Summary

- **Unified leaderboard** — Admin UI and Telegram bot now show identical data from the same source (`_leaderboard.json` written by farm.py)
- **Pre-aggregated admin cache** — Primary node writes `_admin_cache.json` with fleet, queue, and alerts every loop iteration. All admin API endpoints respond in <5ms (was 1-3s)
- **Loading spinners** — All tabs show loading animation during initial data fetch
- **Instant tab switching** — Module-level response cache survives React component unmount/remount, eliminating re-fetch on tab switch
- **Fleet → Nodes** — Tab renamed for clarity
- **Generic cleanup** — Removed project-specific `auc_roc` defaults, made `backbone_registry` import soft, updated `idea_lake.py` defaults to `test_accuracy`
- **Version bump** — farm.py, bot.py, admin/server.py all bumped to v1.10.0

## Changes since v1.9.0

```
305e507 chore: remove project-specific references from orze framework
a743257 feat: farm.py pre-aggregates all admin data into _admin_cache.json
a8578a2 feat: rename Fleet tab to Nodes, pre-warm caches at startup
6e9d6f2 fix: instant tab switching with module-level response cache
a55c797 fix: hooks ordering — early returns must come after all hooks
c8bcacb feat: loading spinners on all tabs
dc6fb66 feat: archived idea index + leaderboard cache in update_report
8822e2c feat: admin panel performance overhaul + unified leaderboard
```

## Test plan

- [x] UI builds successfully (`vite build`)
- [x] Server import works (`python -c "import orze.admin.server"`)
- [x] Admin panel serves leaderboard data correctly
- [x] Tab switching is instant after first load
- [x] No project-specific references remain in types or UI code

🤖 Generated with [Claude Code](https://claude.com/claude-code)