### PR TITLE
chore: Release orze v2.0.1

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4,6 +4,8 @@ You are setting up **orze** — a system that automates the full research loop: 
 
 Read `RULES.md` for the complete technical specification.
 
+> **Shortcut:** For a new project, run `orze --init` to scaffold `train.py`, `orze.yaml`, and `ideas.md` automatically, then jump to step 8.
+
 ## What to do
 
 ### 1. Understand the project (explore first, don't ask)
@@ -107,6 +109,14 @@ roles:
     model: sonnet
     cooldown: 300
     timeout: 600
+    allowed_tools: "Read,Write,Edit,Glob,Grep,Bash,WebSearch,WebFetch"
+
+  # Optional: add more research agents using other LLMs. Orze also
+  # auto-discovers GEMINI_API_KEY / OPENAI_API_KEY from the environment
+  # and creates agents automatically if no roles are configured.
+  # research_gemini:
+  #   mode: research
+  #   backend: gemini
 
 report:
   title: "Research Report"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "orze"
-version = "2.0.0"
+version = "2.0.1"
 description = "GPU experiment orchestrator using filesystem coordination"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/orze/__init__.py
+++ b/src/orze/__init__.py
@@ -1,2 +1,2 @@
 """orze — GPU experiment orchestrator using filesystem coordination."""
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/src/orze/agents/research.py
+++ b/src/orze/agents/research.py
@@ -728,9 +728,15 @@ def _post_json(url: str, payload: dict, headers: dict,
 
 def call_gemini(prompt: str, api_key: str,
                 model: str = "gemini-2.5-flash",
-                max_tokens: int = 8192) -> str:
-    """Call Gemini API. Tries multiple models on failure."""
-    models = [model, "gemini-2.5-flash", "gemini-2.5-pro"]
+                max_tokens: int = 8192,
+                web_search: bool = False) -> str:
+    """Call Gemini API. Tries multiple models on failure.
+
+    Args:
+        web_search: Enable Google Search grounding so Gemini can fetch
+            live web results alongside its own knowledge.
+    """
+    models = [model, "gemini-3-flash-preview", "gemini-2.5-flash"]
     # Deduplicate while preserving order
     seen = set()
     unique_models = []
@@ -747,9 +753,12 @@ def call_gemini(prompt: str, api_key: str,
                 "contents": [{"parts": [{"text": prompt}]}],
                 "generationConfig": {"maxOutputTokens": max_tokens},
             }
+            if web_search:
+                payload["tools"] = [{"google_search": {}}]
             result = _post_json(url, payload, {"Content-Type": "application/json"})
-            text = (result.get("candidates", [{}])[0]
-                    .get("content", {}).get("parts", [{}])[0].get("text", ""))
+            parts = (result.get("candidates", [{}])[0]
+                     .get("content", {}).get("parts", []))
+            text = "\n".join(p.get("text", "") for p in (parts or []) if p.get("text"))
             if text:
                 logger.info("Gemini (%s) returned %d chars", m, len(text))
                 return text
@@ -837,7 +846,8 @@ def call_llm(prompt: str, backend: str, api_key: str = "",
         if not key:
             logger.error("GEMINI_API_KEY not set")
             return ""
-        return call_gemini(prompt, key, model=model or "gemini-2.5-flash")
+        return call_gemini(prompt, key, model=model or "gemini-2.5-flash",
+                          web_search=True)
 
     elif backend == "openai":
         key = api_key or os.environ.get("OPENAI_API_KEY", "")

--- a/src/orze/cli.py
+++ b/src/orze/cli.py
@@ -277,7 +277,12 @@ python: {sys.executable}
         from orze.reporting.leaderboard import update_report
         ideas = parse_ideas(cfg["ideas_file"])
         results_dir = Path(cfg["results_dir"])
-        update_report(results_dir, ideas, cfg)
+        lake = None
+        lake_path = Path(cfg["ideas_file"]).parent / "idea_lake.db"
+        if lake_path.exists():
+            from orze.idea_lake import IdeaLake
+            lake = IdeaLake(str(lake_path))
+        update_report(results_dir, ideas, cfg, lake=lake)
         print("Report updated.")
         return
 

--- a/src/orze/reporting/leaderboard.py
+++ b/src/orze/reporting/leaderboard.py
@@ -160,8 +160,15 @@ def update_report(results_dir: Path, ideas: Dict[str, dict],
                          "status": "IN_PROGRESS", "values": {}})
             continue
 
-        # Check cache: {idea_id: {mtime: float, row: dict}}
+        # Check cache: invalidate if metrics.json OR any source file changed
         mtime = metrics_path.stat().st_mtime
+        # Also track mtime of external source files (e.g. fedex_test_report.json)
+        for col in columns:
+            src = col.get("source", "")
+            if src and ":" in src:
+                src_file = idea_dir / src.split(":", 1)[0]
+                if src_file.exists():
+                    mtime = max(mtime, src_file.stat().st_mtime)
         cached = cache.get(idea_id)
         if cached and cached.get("mtime") == mtime:
             rows.append(cached["row"])


### PR DESCRIPTION
- AGENT.md: add --init shortcut callout and allowed_tools to research role example; note multi-LLM auto-discovery
- Gemini: add web search grounding support (google_search tool), update model fallback list to include gemini-3-flash-preview
- leaderboard: fix cache invalidation to track source file mtimes (not just metrics.json)
- cli: wire IdeaLake into --report-only path for full leaderboard coverage