### PR TITLE
feat: content-hash idea IDs replacing sequential numbers

### DIFF
--- a/src/orze/admin/server.py
+++ b/src/orze/admin/server.py
@@ -272,7 +272,7 @@ async def get_runs(limit: int = 50):
 @app.get("/api/run/detail")
 async def get_run(idea_id: str):
     """Read metrics.json + claim.json for a specific idea."""
-    if not re.match(r"^idea-\d+(-ht-\d+)?(~\d+)?$", idea_id):
+    if not re.match(r"^idea-[a-z0-9]+(-ht-\d+)?(~\d+)?$", idea_id):
         raise HTTPException(400, "Invalid idea_id format")
 
     idea_dir = _results_dir() / idea_id
@@ -295,7 +295,7 @@ async def get_run(idea_id: str):
 @app.get("/api/run/log")
 async def get_run_log(idea_id: str):
     """Tail training.log (last 200 lines)."""
-    if not re.match(r"^idea-\d+(-ht-\d+)?(~\d+)?$", idea_id):
+    if not re.match(r"^idea-[a-z0-9]+(-ht-\d+)?(~\d+)?$", idea_id):
         raise HTTPException(400, "Invalid idea_id format")
 
     idea_dir = _results_dir() / idea_id
@@ -433,26 +433,11 @@ async def post_idea(request: Request):
         try:
             from orze.idea_lake import IdeaLake
             lake = IdeaLake(str(lake_path))
-            next_num = lake.get_next_id()
             lake.close()
         except Exception:
-            # Fallback to scanning ideas.md
-            existing = parse_ideas(_ideas_file())
-            max_num = 0
-            for k in existing:
-                m = re.match(r"^idea-(\d+)", k)
-                if m:
-                    max_num = max(max_num, int(m.group(1)))
-            next_num = max_num + 1
-    else:
-        existing = parse_ideas(_ideas_file())
-        max_num = 0
-        for k in existing:
-            m = re.match(r"^idea-(\d+)", k)
-            if m:
-                max_num = max(max_num, int(m.group(1)))
-        next_num = max_num + 1
-    idea_id = f"idea-{next_num:04d}"
+            pass
+    from orze.agents.research import generate_idea_id
+    idea_id = generate_idea_id(config, _results_dir())
 
     md = format_idea_markdown(
         idea_id=idea_id,
@@ -485,7 +470,7 @@ async def action_kill(request: Request):
         raise HTTPException(400, "Invalid JSON body")
 
     idea_id = body.get("idea_id")
-    if not idea_id or not re.match(r"^idea-\d+(-ht-\d+)?(~\d+)?$", idea_id):
+    if not idea_id or not re.match(r"^idea-[a-z0-9]+(-ht-\d+)?(~\d+)?$", idea_id):
         raise HTTPException(400, "Valid idea_id required (e.g. idea-0042)")
 
     idea_dir = _results_dir() / idea_id

--- a/src/orze/agents/archive_ideas.py
+++ b/src/orze/agents/archive_ideas.py
@@ -28,7 +28,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger("archive_ideas")
 
-_IDEA_PATTERN = re.compile(r"^## (idea-\d+):\s*(.+?)$", re.MULTILINE)
+_IDEA_PATTERN = re.compile(r"^## (idea-[a-z0-9]+):\s*(.+?)$", re.MULTILINE)
 
 
 def parse_all_ideas(text: str):
@@ -51,7 +51,7 @@ def parse_all_ideas(text: str):
         category = cat_match.group(1).lower() if cat_match else "architecture"
 
         # Extract parent
-        par_match = re.search(r"\*\*Parent\*\*:\s*(idea-\d+|none)", raw_block)
+        par_match = re.search(r"\*\*Parent\*\*:\s*(idea-[a-z0-9]+|none)", raw_block)
         parent = par_match.group(1) if par_match and par_match.group(1) != "none" else None
 
         # Extract hypothesis

--- a/src/orze/agents/research.py
+++ b/src/orze/agents/research.py
@@ -142,7 +142,7 @@ def analyze_failures(results_dir: Path,
 
     # Normalize errors into patterns by stripping variable parts
     def _normalize(msg: str) -> str:
-        msg = re.sub(r"idea-\d+", "idea-XXX", msg)
+        msg = re.sub(r"idea-[a-z0-9]+", "idea-XXX", msg)
         msg = re.sub(r"Unknown \w+: \S+", "Unknown <type>: <name>", msg)
         msg = re.sub(r"Stalled \(no output for \d+m\)", "Stalled (hung process)", msg)
         msg = re.sub(r"\d+\.\d+", "N", msg)
@@ -357,7 +357,7 @@ def get_existing_idea_ids(ideas_path: Path) -> List[str]:
     if not ideas_path.exists():
         return []
     text = ideas_path.read_text(encoding="utf-8")
-    return [m.group(1) for m in re.finditer(r"^## (idea-\d+):", text, re.MULTILINE)]
+    return [m.group(1) for m in re.finditer(r"^## (idea-[a-z0-9]+):", text, re.MULTILINE)]
 
 
 def parse_idea_configs(ideas_path: Path) -> Dict[str, dict]:
@@ -366,7 +366,7 @@ def parse_idea_configs(ideas_path: Path) -> Dict[str, dict]:
         return {}
     text = ideas_path.read_text(encoding="utf-8")
     ideas = {}
-    pattern = re.compile(r"^## (idea-\d+):\s*(.+?)$", re.MULTILINE)
+    pattern = re.compile(r"^## (idea-[a-z0-9]+):\s*(.+?)$", re.MULTILINE)
     matches = list(pattern.finditer(text))
     for i, m in enumerate(matches):
         idea_id = m.group(1)
@@ -384,14 +384,22 @@ def parse_idea_configs(ideas_path: Path) -> Dict[str, dict]:
     return ideas
 
 
-def next_idea_id(existing_ids: List[str]) -> int:
-    """Get the next available idea number."""
-    nums = []
-    for id_str in existing_ids:
-        m = re.match(r"idea-(\d+)", id_str)
-        if m:
-            nums.append(int(m.group(1)))
-    return max(nums) + 1 if nums else 1
+def generate_idea_id(config: dict, results_dir: Path) -> str:
+    """Generate a 6-char content-hash idea ID, collision-free.
+
+    Hash = sha256(yaml.dump(config, sort_keys=True) + nonce)[:6].
+    Checks results/ to avoid collisions with existing experiments.
+    """
+    import hashlib
+    import time as _time
+    raw = yaml.dump(config, sort_keys=True)
+    for nonce in range(100):
+        h = hashlib.sha256(f"{raw}:{nonce}".encode()).hexdigest()[:6]
+        idea_id = f"idea-{h}"
+        if not (results_dir / idea_id).exists():
+            return idea_id
+    # Fallback: timestamp-based
+    return f"idea-{hashlib.sha256(f'{raw}:{_time.time()}'.encode()).hexdigest()[:6]}"
 
 
 def build_context(results_dir: Path, ideas_path: Path, report_cfg: dict,
@@ -611,11 +619,12 @@ def append_ideas_to_md(ideas_md: list, ideas_path: Path,
 #  LLM response parsing (generic — extracts ideas from LLM output)
 # ---------------------------------------------------------------------------
 
-def parse_llm_ideas(response: str, start_id: int, cycle: int) -> list:
+def parse_llm_ideas(response: str, results_dir: Path, cycle: int) -> list:
     """Parse LLM response into structured ideas.
 
     Expects the LLM to return ideas as JSON array or markdown.
     Tries JSON first, falls back to markdown parsing.
+    IDs are 6-char content hashes of the config YAML.
 
     Each idea needs: title, hypothesis, config (dict).
     Optional: priority, category, parent.
@@ -630,7 +639,7 @@ def parse_llm_ideas(response: str, start_id: int, cycle: int) -> list:
                 continue
             if not item.get("title") or not item.get("config"):
                 continue
-            idea_id = f"idea-{start_id + i:04d}"
+            idea_id = generate_idea_id(item["config"], results_dir)
             ideas.append({
                 "idea_id": idea_id,
                 "title": item["title"],
@@ -645,7 +654,7 @@ def parse_llm_ideas(response: str, start_id: int, cycle: int) -> list:
 
     # Fallback: try to find YAML blocks in markdown
     pattern = re.compile(
-        r"##\s*(?:idea-\d+:\s*)?(.+?)$\s*"
+        r"##\s*(?:idea-[a-z0-9]+:\s*)?(.+?)$\s*"
         r"(?:.*?hypothesis[:\s]*(.+?)$)?\s*"
         r"```ya?ml\s*\n(.*?)```",
         re.MULTILINE | re.DOTALL | re.IGNORECASE,
@@ -659,7 +668,7 @@ def parse_llm_ideas(response: str, start_id: int, cycle: int) -> list:
             continue
         if not isinstance(config, dict):
             continue
-        idea_id = f"idea-{start_id + i:04d}"
+        idea_id = generate_idea_id(config, results_dir)
         ideas.append({
             "idea_id": idea_id,
             "title": title,
@@ -911,21 +920,24 @@ Return a JSON array of ideas. Each idea is an object with:
 - "config": YAML-compatible dict with experiment config (object)
 - "priority": "critical" | "high" | "medium" | "low" (string, optional)
 - "category": free-form label like "architecture", "hyperparameter", "loss" (string, optional)
-- "parent": "none" or "idea-XXX" if building on a previous idea (string, optional)
+- "parent": "none" or an existing idea ID if building on a previous idea (string, optional)
+
+Note: idea IDs are auto-generated as 6-char content hashes (e.g. "idea-a7f3b2").
+You do NOT need to assign IDs — just provide the config and orze will hash it.
 
 Example:
 ```json
 [
   {
     "title": "Larger learning rate with cosine schedule",
-    "hypothesis": "Current best (idea-042) uses lr=1e-4. A 3x larger lr with cosine decay may converge faster and find a better minimum.",
+    "hypothesis": "Current best uses lr=1e-4. A 3x larger lr with cosine decay may converge faster and find a better minimum.",
     "config": {
       "model": {"type": "resnet50", "pretrained": true},
       "training": {"lr": 3e-4, "scheduler": "cosine", "epochs": 20}
     },
     "priority": "high",
     "category": "hyperparameter",
-    "parent": "idea-042"
+    "parent": "none"
   }
 ]
 ```
@@ -981,8 +993,7 @@ def run_research_cycle(
     context = build_context(results_dir, ideas_path, report_cfg,
                             lake_db_path=lake_db_path)
     existing_ids = get_existing_idea_ids(ideas_path)
-    start_id = next_idea_id(existing_ids)
-    logger.info("  %d existing ideas, next ID: idea-%04d", len(existing_ids), start_id)
+    logger.info("  %d existing ideas in queue, using content-hash IDs", len(existing_ids))
 
     # 2. Load project-specific rules if provided
     rules_content = ""
@@ -1014,7 +1025,7 @@ def run_research_cycle(
 
     # 5. Parse ideas from response
     logger.info("Step 3: Parsing ideas from response...")
-    ideas = parse_llm_ideas(response, start_id, cycle)
+    ideas = parse_llm_ideas(response, results_dir, cycle)
     if not ideas:
         logger.warning("Could not parse any ideas from LLM response")
         logger.debug("Response was: %s", response[:2000])

--- a/src/orze/agents/train_idea.py
+++ b/src/orze/agents/train_idea.py
@@ -149,7 +149,7 @@ def get_idea_config(ideas_md: str, idea_id: str) -> dict:
         text = Path(ideas_md).read_text(encoding="utf-8")
     except FileNotFoundError:
         return {}
-    pattern = re.compile(r"^## (idea-\d+):\s*(.+?)$", re.MULTILINE)
+    pattern = re.compile(r"^## (idea-[a-z0-9]+):\s*(.+?)$", re.MULTILINE)
     matches = list(pattern.finditer(text))
 
     for i, m in enumerate(matches):

--- a/src/orze/core/ideas.py
+++ b/src/orze/core/ideas.py
@@ -31,7 +31,7 @@ def parse_ideas(path: str) -> Dict[str, dict]:
     except OSError:
         return {}
     ideas = {}
-    pattern = re.compile(r"^## (idea-\d+):\s*(.+?)$", re.MULTILINE)
+    pattern = re.compile(r"^## (idea-[a-z0-9]+):\s*(.+?)$", re.MULTILINE)
     matches = list(pattern.finditer(text))
 
     for i, m in enumerate(matches):

--- a/src/orze/engine/orchestrator.py
+++ b/src/orze/engine/orchestrator.py
@@ -639,7 +639,7 @@ class Orze:
         if ideas_file.exists():
             ideas_pre_size = ideas_file.stat().st_size
             ideas_pre_count = len(re.findall(
-                r"^## idea-\d+:", ideas_file.read_text(encoding="utf-8"),
+                r"^## idea-[a-z0-9]+:", ideas_file.read_text(encoding="utf-8"),
                 re.MULTILINE))
             # Rotate backups: keep last 3
             # Wrapped in try/except: on shared FSX, concurrent roles can race

--- a/src/orze/engine/roles.py
+++ b/src/orze/engine/roles.py
@@ -68,7 +68,7 @@ def _check_ideas_integrity(ideas_file: str, rp: "RoleProcess"):
     # File shrunk — check idea count to confirm corruption
     try:
         current_text = ideas_path.read_text(encoding="utf-8")
-        current_count = len(re.findall(r"^## idea-\d+:", current_text,
+        current_count = len(re.findall(r"^## idea-[a-z0-9]+:", current_text,
                                        re.MULTILINE))
     except OSError:
         current_count = 0
@@ -92,7 +92,7 @@ def _check_ideas_integrity(ideas_file: str, rp: "RoleProcess"):
     if backup_path.exists():
         try:
             backup_text = backup_path.read_text(encoding="utf-8")
-            backup_count = len(re.findall(r"^## idea-\d+:", backup_text,
+            backup_count = len(re.findall(r"^## idea-[a-z0-9]+:", backup_text,
                                           re.MULTILINE))
         except OSError:
             backup_count = 0

--- a/src/orze/engine/scheduler.py
+++ b/src/orze/engine/scheduler.py
@@ -29,8 +29,7 @@ def get_unclaimed(ideas: Dict[str, dict], results_dir: Path,
 
     def sort_key(idea_id):
         pri = PRIORITY_ORDER.get(ideas[idea_id]["priority"], 2)
-        match = re.search(r"\d+", idea_id)
-        return (pri, int(match.group()) if match else 999999)
+        return (pri, idea_id)
 
     unclaimed.sort(key=sort_key)
     return unclaimed

--- a/src/orze/idea_lake.py
+++ b/src/orze/idea_lake.py
@@ -110,11 +110,15 @@ class IdeaLake:
             # Backfill
             rows = self.conn.execute("SELECT idea_id FROM ideas").fetchall()
             for r in rows:
-                match = re.search(r"idea-(\d+)", r["idea_id"])
+                match = re.search(r"idea-([a-z0-9]+)", r["idea_id"])
                 if match:
+                    try:
+                        num = int(match.group(1))
+                    except ValueError:
+                        num = int(match.group(1), 16) % (2**31)
                     self.conn.execute(
                         "UPDATE ideas SET id_num = ? WHERE idea_id = ?",
-                        (int(match.group(1)), r["idea_id"])
+                        (num, r["idea_id"])
                     )
             self.conn.commit()
             logger.info("Backfilled id_num for %d ideas", len(rows))
@@ -165,11 +169,14 @@ class IdeaLake:
         created_at: Optional[str] = None,
     ):
         """Insert or update an idea in the lake."""
-        # Extract numeric ID for indexed sorting
+        # Extract numeric ID for indexed sorting (supports both numeric and hex IDs)
         id_num = None
-        match = re.search(r"idea-(\d+)", idea_id)
+        match = re.search(r"idea-([a-z0-9]+)", idea_id)
         if match:
-            id_num = int(match.group(1))
+            try:
+                id_num = int(match.group(1))
+            except ValueError:
+                id_num = int(match.group(1), 16) % (2**31)
 
         # Auto-compute summary if missing
         if not config_summary and config_yaml:
@@ -389,10 +396,15 @@ class IdeaLake:
                 except yaml.YAMLError:
                     pass
 
-            # Extract numeric ID for sorting
+            # Extract numeric ID for sorting (supports both numeric and hex IDs)
             id_num = None
             try:
-                id_num = int(re.search(r"\d+", idea["idea_id"]).group())
+                match = re.search(r"idea-([a-z0-9]+)", idea["idea_id"])
+                if match:
+                    try:
+                        id_num = int(match.group(1))
+                    except ValueError:
+                        id_num = int(match.group(1), 16) % (2**31)
             except (AttributeError, ValueError):
                 pass
 

--- a/src/orze/reporting/leaderboard.py
+++ b/src/orze/reporting/leaderboard.py
@@ -107,8 +107,7 @@ def update_report(results_dir: Path, ideas: Dict[str, dict],
 
     rows = []
     def _id_sort_key(x):
-        match = re.search(r"\d+", x)
-        return int(match.group()) if match else 999999
+        return x
 
     # Include archived ideas from cached index
     all_ideas = dict(ideas)


### PR DESCRIPTION
## Summary
- Replace sequential numeric IDs (`idea-0001`) with 6-char SHA256 content hashes (`idea-a7f3b2`)
- Eliminates ID collision bugs where new ideas collide with archived result directories
- `generate_idea_id(config, results_dir)` hashes the YAML config, checks results/ for collisions
- Updated all 17 regex patterns from `idea-\d+` to `idea-[a-z0-9]+` across 10 files
- Both old numeric and new hex IDs coexist seamlessly

## Test plan
- [x] `generate_idea_id()` produces unique 6-char hex IDs
- [x] Same config → same ID (content-addressable)
- [x] Collision detection works (creates different nonce when dir exists)
- [x] `parse_ideas()` handles both hex and numeric IDs
- [x] No `idea-\d+` patterns remain in codebase
- [x] Orze starts and trains existing queue ideas

🤖 Generated with [Claude Code](https://claude.com/claude-code)