### PR TITLE
fix: env var expansion, auto-discovery override, research PYTHONPATH

### DIFF
--- a/src/orze/__init__.py
+++ b/src/orze/__init__.py
@@ -1,2 +1,2 @@
 """orze — orze.ai."""
-__version__ = "2.14.0"
+__version__ = "2.14.1"

--- a/src/orze/core/config.py
+++ b/src/orze/core/config.py
@@ -24,6 +24,7 @@ CALLING SPEC:
         Returns count of vars loaded.
 """
 import os
+import re
 import logging
 import copy
 from typing import Optional
@@ -33,6 +34,22 @@ import yaml
 logger = logging.getLogger("orze")
 
 import sys
+
+_ENV_VAR_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _expand_env_vars(obj):
+    """Recursively expand ${VAR} references in string values using os.environ."""
+    if isinstance(obj, str):
+        def _replace(m):
+            return os.environ.get(m.group(1), m.group(0))
+        return _ENV_VAR_RE.sub(_replace, obj)
+    if isinstance(obj, dict):
+        return {k: _expand_env_vars(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_expand_env_vars(item) for item in obj]
+    return obj
+
 
 def find_dotenv(config_path: Optional[str] = None) -> Optional[Path]:
     """Find .env file: next to config or CWD. Returns path or None."""
@@ -157,6 +174,9 @@ def load_project_config(path: Optional[str] = None) -> dict:
     elif path:
         logger.warning("Config file %s not found, using defaults", path)
 
+    # Expand ${VAR} references in config values using os.environ
+    cfg = _expand_env_vars(cfg)
+
     # Migrate legacy research: into roles: dict
     if "research" in cfg and isinstance(cfg["research"], dict):
         logger.warning("Migrating legacy 'research:' config to 'roles: {research: ...}'. "
@@ -167,13 +187,11 @@ def load_project_config(path: Optional[str] = None) -> dict:
             cfg["roles"]["research"] = cfg["research"]
 
     # Auto-discover research backends from environment API keys.
-    # Only activates if no research roles are explicitly configured.
+    # Only activates if NO roles are explicitly configured at all.
+    # If the user defined any roles (even mode: script), respect that
+    # and don't inject auto-discovered backends alongside them.
     roles = cfg.get("roles") or {}
-    has_research_role = any(
-        isinstance(rc, dict) and rc.get("mode") in ("claude", "research")
-        for rc in roles.values()
-    )
-    if not has_research_role:
+    if not roles:
         _AUTO_BACKENDS = [
             ("GEMINI_API_KEY", "gemini", "gemini-2.5-flash"),
             ("OPENAI_API_KEY", "openai", "gpt-4o"),

--- a/src/orze/engine/role_runner.py
+++ b/src/orze/engine/role_runner.py
@@ -354,6 +354,14 @@ def run_role_step(role_name: str, role_cfg: dict, ctx: RoleContext) -> None:
         env[k] = str(v)
     for k, v in (role_cfg.get("env") or {}).items():
         env[k] = str(v)
+    # Ensure orze package is importable by built-in agents (mode: research)
+    # even when cfg.python points to a different venv
+    if mode == "research":
+        orze_src = str(Path(__file__).parent.parent.parent)
+        existing = env.get("PYTHONPATH", "")
+        if orze_src not in existing.split(os.pathsep):
+            env["PYTHONPATH"] = (
+                f"{orze_src}{os.pathsep}{existing}" if existing else orze_src)
 
     # Per-role log directory
     log_dir_name = role_cfg.get("log_dir") or f"_{role_name}_logs"


### PR DESCRIPTION
## Summary
- **${VAR} expansion**: Config string values containing `${VAR}` are now expanded from `os.environ` after YAML loading. Fixes Telegram notifications using literal `${TELEGRAM_BOT_TOKEN}` instead of the actual token.
- **Auto-discovery override**: Backend auto-discovery now only fires when no roles are configured at all. Prevents injecting `research_gemini` alongside explicit `mode: script` roles.
- **Research agent PYTHONPATH**: Built-in research agent subprocess gets `PYTHONPATH` pointing to orze src, fixing `ModuleNotFoundError: No module named 'orze'` when `cfg.python` is a different venv.

Bumps version to 2.14.1.

## Test plan
- [x] `_expand_env_vars` correctly substitutes `${VAR}` from env, leaves undefined vars as-is
- [x] Auto-discovery skipped when any roles are explicitly configured (even `mode: script`)
- [x] PYTHONPATH injected only for `mode: research` subprocesses

🤖 Generated with [Claude Code](https://claude.com/claude-code)