### PR TITLE
fix: clear feedback when research agent is not configured

### DIFF
--- a/src/orze/__init__.py
+++ b/src/orze/__init__.py
@@ -1,2 +1,2 @@
 """orze — orze.ai."""
-__version__ = "2.15.0"
+__version__ = "2.15.1"

--- a/src/orze/cli.py
+++ b/src/orze/cli.py
@@ -1126,16 +1126,24 @@ noise: 0.1
             print(f"    {no} No GPUs detected")
 
         # --- Roles ---
+        print()
+        print("  \033[1mResearch Agent:\033[0m")
         roles = cfg.get("roles") or {}
         if roles:
-            print()
-            print("  \033[1mRoles:\033[0m")
             for rname, rcfg in roles.items():
                 if isinstance(rcfg, dict):
                     mode = rcfg.get("mode", "script")
                     backend = rcfg.get("backend", "")
                     detail = f"mode={mode}" + (f", backend={backend}" if backend else "")
                     print(f"    {ok} {rname}: {detail}")
+        else:
+            print(f"    {no} No research agent configured — ideas will not be generated automatically")
+            if not any_key:
+                print(f"      hint: add an API key to .env (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY)")
+                print(f"            orze will auto-discover it and start generating ideas")
+            else:
+                print(f"      hint: auto-discovery found API key(s) but roles section in orze.yaml")
+                print(f"            may be overriding it. Remove 'roles: {{}}' or configure a research role")
 
         # --- Validation ---
         errors, warnings = _validate_config(cfg)

--- a/src/orze/core/config.py
+++ b/src/orze/core/config.py
@@ -211,6 +211,9 @@ def load_project_config(path: Optional[str] = None) -> dict:
         if discovered:
             logger.info("Auto-discovered research backends: %s",
                         ", ".join(discovered))
+        else:
+            logger.info("No API keys found in environment — research agent will not run. "
+                        "Add GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY to .env")
 
     return cfg
 
@@ -269,7 +272,9 @@ def _validate_config(cfg: dict) -> tuple:
         warnings.append(f"eval_script not found: {es}")
 
     if not roles:
-        warnings.append("No roles configured — idea generation disabled")
+        warnings.append("No research agent configured — idea generation disabled. "
+                        "Add an API key to .env (GEMINI_API_KEY, OPENAI_API_KEY, or "
+                        "ANTHROPIC_API_KEY) for auto-discovery, or configure roles: in orze.yaml")
 
     # Check for API keys if research roles exist
     has_research = roles and any(


### PR DESCRIPTION
## Summary
- `orze --check` now always shows **Research Agent** section — previously it was silently hidden when no roles were configured
- Startup warning upgraded from vague "No roles configured" to actionable: lists exactly which API keys to add to `.env`
- Auto-discovery now logs when it finds no API keys, so users know *why* research isn't running

Before:
```
  Roles:
  (nothing shown)
```

After:
```
  Research Agent:
  [ ] No research agent configured — ideas will not be generated automatically
      hint: add an API key to .env (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY)
            orze will auto-discover it and start generating ideas
```

## Test plan
- [ ] `orze --check` with no API keys shows the hint
- [ ] `orze --check` with API key shows auto-discovered role
- [ ] Startup log shows actionable warning when no research agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)